### PR TITLE
[BE] fix: 게시물 삭제시 댓글 삭제 연동 / Board, Comment, Goal 500 에러 수정

### DIFF
--- a/server/src/main/java/com/codestates/server/board/service/BoardService.java
+++ b/server/src/main/java/com/codestates/server/board/service/BoardService.java
@@ -3,6 +3,8 @@ package com.codestates.server.board.service;
 
 import com.codestates.server.board.entity.Board;
 import com.codestates.server.board.repository.BoardRepository;
+import com.codestates.server.comment.entity.Comment;
+import com.codestates.server.comment.repository.CommentRepository;
 import com.codestates.server.exception.BusinessLogicException;
 import com.codestates.server.exception.ExceptionCode;
 import org.springframework.data.domain.Page;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Transactional(readOnly = true)
@@ -19,8 +22,11 @@ public class BoardService {
 
     private final BoardRepository repository;
 
-    public BoardService(BoardRepository repository) {
+    private final CommentRepository commentRepository;
+
+    public BoardService(BoardRepository repository, CommentRepository commentRepository) {
         this.repository = repository;
+        this.commentRepository = commentRepository;
     }
 
     public Board findOne(long id) {
@@ -84,8 +90,12 @@ public class BoardService {
     public void deleteOne(Long id) {
         Board verifiedBoard = findVerifiedBoard(id);
 
-        // only status is changed
+        // only board's status is changed
         verifiedBoard.setBoardStatus(Board.BoardStatus.BOARD_DELETED);
+
+        // delete related comments
+        List<Comment> relatedComments = commentRepository.findAll(id);
+        commentRepository.deleteAllInBatch(relatedComments);
     }
 
     public Board findVerifiedBoard(long id) {

--- a/server/src/main/java/com/codestates/server/board/service/BoardService.java
+++ b/server/src/main/java/com/codestates/server/board/service/BoardService.java
@@ -6,6 +6,7 @@ import com.codestates.server.board.repository.BoardRepository;
 import com.codestates.server.comment.entity.Comment;
 import com.codestates.server.comment.repository.CommentRepository;
 import com.codestates.server.exception.BusinessLogicException;
+import com.codestates.server.exception.CustomException;
 import com.codestates.server.exception.ExceptionCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -100,6 +101,11 @@ public class BoardService {
 
     public Board findVerifiedBoard(long id) {
         Optional<Board> optionalBoard = repository.findById(id);
-        return optionalBoard.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BOARD_NOT_FOUND));
+        Board board = optionalBoard.orElseThrow(() -> new CustomException(ExceptionCode.BOARD_NOT_FOUND));
+
+        if (board.getBoardStatus() == Board.BoardStatus.BOARD_DELETED) {
+            throw new CustomException(ExceptionCode.BOARD_DELETED);
+        }
+        return board;
     }
 }

--- a/server/src/main/java/com/codestates/server/comment/repository/CommentRepository.java
+++ b/server/src/main/java/com/codestates/server/comment/repository/CommentRepository.java
@@ -2,6 +2,13 @@ package com.codestates.server.comment.repository;
 
 import com.codestates.server.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    // 게시물 연관 댓글
+    @Query(nativeQuery = true, value = "select * from Comment where board_id = :id")
+    List<Comment> findAll(long id);
 }

--- a/server/src/main/java/com/codestates/server/comment/service/CommentService.java
+++ b/server/src/main/java/com/codestates/server/comment/service/CommentService.java
@@ -4,7 +4,7 @@ import com.codestates.server.board.entity.Board;
 import com.codestates.server.board.service.BoardService;
 import com.codestates.server.comment.entity.Comment;
 import com.codestates.server.comment.repository.CommentRepository;
-import com.codestates.server.exception.BusinessLogicException;
+import com.codestates.server.exception.CustomException;
 import com.codestates.server.exception.ExceptionCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,6 +63,6 @@ public class CommentService {
 
     public Comment findVerifiedComment(long id) {
         Optional<Comment> optionalComment = repository.findById(id);
-        return optionalComment.orElseThrow(() -> new BusinessLogicException(ExceptionCode.COMMENT_NOT_FOUND));
+        return optionalComment.orElseThrow(() -> new CustomException(ExceptionCode.COMMENT_NOT_FOUND));
     }
 }

--- a/server/src/main/java/com/codestates/server/exception/ExceptionCode.java
+++ b/server/src/main/java/com/codestates/server/exception/ExceptionCode.java
@@ -8,8 +8,8 @@ public enum ExceptionCode {
     //유저
     DUPLICATE_MEMBER(409, "해당 아이디는 이미 존재합니다."),
     MEMBER_NOT_FOUND(404, "존재하지 않는 아이디 입니다."),
-
     DUPLICATE_RESOURCE(409, "데이터가 이미 존재합니다"),
+    USER_EXISTS(409, "User exists"),
 
     //토큰
     INVALID_REFRESH_TOKEN(400, "리프레시 토큰이 유효하지 않습니다"),
@@ -18,29 +18,22 @@ public enum ExceptionCode {
     INVALID_AUTH_TOKEN(401, "권한 정보가 없는 토큰입니다"),
     REFRESH_TOKEN_NOT_FOUND(404, "로그아웃 된 사용자입니다"),
 
-    //게시글
-    POST_NOT_FOUND(404, "존재하지 않는 게시글입니다."),
-    LIKE_NOT_ACCEPTED(400, "회원당 한번만 좋아요를 누를 수 있습니다."),
-    ANSWER_NOT_FOUND(404, "존재하지 않는 답변입니다."),
     //시큐리티
     USER_NOT_FOUNT(404, "로그인 시도중 -> 해당 유저가 존재하지 않습니다."),
 
+    // 게시글
+    BOARD_NOT_FOUND(404, "존재하지 않는 게시글입니다."),
+    BOARD_DELETED(405, "삭제된 게시물 입니다."),
+    LIKE_NOT_ACCEPTED(400, "회원당 한번만 좋아요를 누를 수 있습니다."),
 
-    USER_NOT_FOUND(404, "User not found"),
-    USER_EXISTS(409, "User exists"),
-    INVALID_USER_STATUS(400, "Invalid user status"),
+    // 댓글
+    COMMENT_NOT_FOUND(404, "존재하지 않는 댓글입니다."),
 
-    ORDER_NOT_FOUND(404, "Order not found"),
-    CANNOT_CHANGE_ORDER(403, "Order can not change"),
+    // 자산
+    ASSET_NOT_FOUND(404, "존재하지 않는 자산입니다."),
 
-    NOT_IMPLEMENTATION(501, "Not Implementation"),
-
-    BOARD_NOT_FOUND(404, "Board not found"),
-    ASSET_NOT_FOUND(404, "Asset not found"),
-
-    COMMENT_NOT_FOUND(404, "Comment not found"),
-
-    GOAL_NOT_FOUND(404, "Goal not found");
+    // 목표 자산
+    GOAL_NOT_FOUND(404, "존재하지 않는 목표 자산입니다.");
 
     @Getter
     private int status;

--- a/server/src/main/java/com/codestates/server/goal/service/GoalService.java
+++ b/server/src/main/java/com/codestates/server/goal/service/GoalService.java
@@ -1,6 +1,6 @@
 package com.codestates.server.goal.service;
 
-import com.codestates.server.exception.BusinessLogicException;
+import com.codestates.server.exception.CustomException;
 import com.codestates.server.exception.ExceptionCode;
 import com.codestates.server.goal.entity.Goal;
 import com.codestates.server.goal.repository.GoalRepository;
@@ -80,6 +80,6 @@ public class GoalService {
 
     public Goal findVerifiedGoal(long id) {
         Optional<Goal> optionalGoal = repository.findById(id);
-        return optionalGoal.orElseThrow(() -> new BusinessLogicException(ExceptionCode.GOAL_NOT_FOUND));
+        return optionalGoal.orElseThrow(() -> new CustomException(ExceptionCode.GOAL_NOT_FOUND));
     }
 }


### PR DESCRIPTION
변동 사항:

- 게시물 삭제할 때 해당 게시물의 댓글도 함께 삭제되도록 연동하였습니다.
- 삭제된 게시물, 댓글, 목표자산 조회시 500 에러 발생을 404, 405 등 해당 에러에 맞게 수정하였습니다.