### PR TITLE
[BE] fix: 게시물 페이지정보 추가 / 전체 조회 추가

### DIFF
--- a/server/src/main/java/com/codestates/server/board/controller/BoardController.java
+++ b/server/src/main/java/com/codestates/server/board/controller/BoardController.java
@@ -5,10 +5,11 @@ import com.codestates.server.board.dto.BoardDto;
 import com.codestates.server.board.entity.Board;
 import com.codestates.server.board.mapper.BoardMapper;
 import com.codestates.server.board.service.BoardService;
+import com.codestates.server.dto.MultiResponseDto;
 import org.springframework.data.domain.Page;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.IanaLinkRelations;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -17,9 +18,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping("/board")
@@ -46,19 +44,22 @@ public class BoardController {
     }
 
     @GetMapping
-    public CollectionModel<EntityModel<BoardDto.Response>> getBoards(@Positive @RequestParam int page,
-                                                                     @Positive @RequestParam int size) {
+    public ResponseEntity getBoards(@Positive @RequestParam int page,
+                                    @Positive @RequestParam int size) {
 
-        Page<Board> pagedBoards = boardService.findAll(page - 1, size);
+        Page<Board> pagedBoards = boardService.findAllByPage(page - 1, size);
         List<Board> listedBoards = pagedBoards.getContent();
 
         List<EntityModel<BoardDto.Response>> boards = listedBoards.stream()
                 .map(mapper::boardToBoardResponseDto)
                 .map(assembler::toModel)
                 .collect(Collectors.toList());
+//
+//        return CollectionModel.of(boards,
+//                linkTo(methodOn(BoardService.class).findAllByPage(page - 1, size)).withSelfRel());
 
-        return CollectionModel.of(boards,
-                linkTo(methodOn(BoardService.class).findAll(page - 1, size)).withSelfRel());
+        return new ResponseEntity<>(
+                new MultiResponseDto<>(boards, pagedBoards), HttpStatus.OK);
     }
 
     @PostMapping

--- a/server/src/main/java/com/codestates/server/board/controller/BoardController.java
+++ b/server/src/main/java/com/codestates/server/board/controller/BoardController.java
@@ -7,6 +7,7 @@ import com.codestates.server.board.mapper.BoardMapper;
 import com.codestates.server.board.service.BoardService;
 import com.codestates.server.dto.MultiResponseDto;
 import org.springframework.data.domain.Page;
+import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.http.HttpStatus;
@@ -18,6 +19,9 @@ import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping("/board")
@@ -60,6 +64,20 @@ public class BoardController {
 
         return new ResponseEntity<>(
                 new MultiResponseDto<>(boards, pagedBoards), HttpStatus.OK);
+    }
+
+    // Page 없는 전체 게시물 조회
+    @GetMapping("/all")
+    public CollectionModel<EntityModel<BoardDto.Response>> getBoards() {
+
+        List<Board> boards = boardService.findAll();
+        List<EntityModel<BoardDto.Response>> response = boards.stream()
+                .map(mapper::boardToBoardResponseDto)
+                .map(assembler::toModel)
+                .collect(Collectors.toList());
+
+        return CollectionModel.of(response,
+                linkTo(methodOn(BoardService.class).findAll()).withSelfRel());
     }
 
     @PostMapping

--- a/server/src/main/java/com/codestates/server/board/repository/BoardRepository.java
+++ b/server/src/main/java/com/codestates/server/board/repository/BoardRepository.java
@@ -10,7 +10,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query(nativeQuery = true, value = "select * from Board where board_status > 0"
             + " order by board_id asc")
-    Page<Board> findAll(Pageable pageable);
+    Page<Board> findAllPaged(Pageable pageable);
 
     // status -> posted 만 조회
 }

--- a/server/src/main/java/com/codestates/server/board/repository/BoardRepository.java
+++ b/server/src/main/java/com/codestates/server/board/repository/BoardRepository.java
@@ -6,11 +6,17 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    // status -> posted 만 조회
 
     @Query(nativeQuery = true, value = "select * from Board where board_status > 0"
             + " order by board_id asc")
     Page<Board> findAllPaged(Pageable pageable);
 
-    // status -> posted 만 조회
+    @Query(nativeQuery = true, value = "select * from Board where board_status > 0"
+            + " order by board_id asc")
+    List<Board> findAll();
 }

--- a/server/src/main/java/com/codestates/server/board/service/BoardService.java
+++ b/server/src/main/java/com/codestates/server/board/service/BoardService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,9 +39,9 @@ public class BoardService {
         return verifiedBoard;
     }
 
-//    public List<Board> findAll() {
-//        return new ArrayList<>(repository.findAll());
-//    }
+    public List<Board> findAll() {
+        return new ArrayList<>(repository.findAll());
+    }
 
     public Page<Board> findAllByPage(int page, int size) {
         return repository.findAllPaged(PageRequest.of(page, size));

--- a/server/src/main/java/com/codestates/server/board/service/BoardService.java
+++ b/server/src/main/java/com/codestates/server/board/service/BoardService.java
@@ -42,8 +42,8 @@ public class BoardService {
 //        return new ArrayList<>(repository.findAll());
 //    }
 
-    public Page<Board> findAll(int page, int size) {
-        return repository.findAll(PageRequest.of(page, size));
+    public Page<Board> findAllByPage(int page, int size) {
+        return repository.findAllPaged(PageRequest.of(page, size));
     }
 
     @Transactional

--- a/server/src/main/java/com/codestates/server/comment/assembler/CommentAssembler.java
+++ b/server/src/main/java/com/codestates/server/comment/assembler/CommentAssembler.java
@@ -4,6 +4,7 @@ import com.codestates.server.comment.controller.CommentController;
 import com.codestates.server.comment.dto.CommentDto;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.stereotype.Component;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -15,7 +16,7 @@ public class CommentAssembler implements RepresentationModelAssembler <CommentDt
     @Override
     public EntityModel<CommentDto.Response> toModel(CommentDto.Response comment) {
         return EntityModel.of(comment,
-                linkTo(methodOn(CommentController.class).getComment(comment.getCommentId())).withSelfRel(),
+                WebMvcLinkBuilder.linkTo(methodOn(CommentController.class).getComment(comment.getCommentId())).withSelfRel(),
                 linkTo(methodOn(CommentController.class).getComments()).withRel("comments"));
     }
 }

--- a/server/src/main/java/com/codestates/server/goal/assembler/GoalAssembler.java
+++ b/server/src/main/java/com/codestates/server/goal/assembler/GoalAssembler.java
@@ -4,6 +4,7 @@ import com.codestates.server.goal.controller.GoalController;
 import com.codestates.server.goal.dto.GoalDto;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.stereotype.Component;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -15,7 +16,7 @@ public class GoalAssembler implements RepresentationModelAssembler<GoalDto.Respo
     @Override
     public EntityModel<GoalDto.Response> toModel(GoalDto.Response goal) {
         return EntityModel.of(goal,
-                linkTo(methodOn(GoalController.class).getGoal(goal.getGoalId())).withSelfRel(),
+                WebMvcLinkBuilder.linkTo(methodOn(GoalController.class).getGoal(goal.getGoalId())).withSelfRel(),
                 linkTo(methodOn(GoalController.class).getGoals()).withRel("goals"));
     }
 }


### PR DESCRIPTION
변경사항:
- 게시물 전체 조회시 페이지 정보 추가 (HAL 포맷 차용하지 않았기 때문에 api 명세서 확인이 필요합니다)
- 게시물 페이지 정보 없이 전체 조회 (`board/all`)